### PR TITLE
Add configuration setting to provide wrapping expression

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,14 +12,16 @@ function activate(context) {
     editor = vscode.window.activeTextEditor;
     let lang = editor.document.languageId;
     if(lang == 'javascript'||lang=='typescript'){
-      let selection = editor.selection; 
+      let selection = editor.selection;
       let line = editor.document.lineAt(selection.active.line);
       let text = editor.document.getText(selection);
       let dest = selection.active;
       dest = dest.translate(0, -dest.character);
       let startSpace = ' '.repeat(line.firstNonWhitespaceCharacterIndex);
       let textEsc = "'"+JSON.stringify(text+':')+"'";
-      let log = startSpace + `console.log(${textEsc}, ${text});\n`;
+      const { wrapperExpression } = vscode.workspace.getConfiguration('consoleLog');
+      const consoleValue = wrapperExpression ? wrapperExpression.replace('$', text) : text;
+      const log = startSpace + `console.log(${textEsc}, ${consoleValue});\n`;
       editor.edit(editBuilder => {
         editBuilder.insert(dest, log);
       });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,31 @@
                 "when": "editorTextFocus",
                 "command": "extension.clog"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Console Log",
+            "properties": {
+                "consoleLog.wrapperExpression": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Expression to call in console log, with the value represented as $. (E.g. JSON.stringify($)).",
+                    "scope": "resource"
+                }
+            }
+        },
+        "configurationAttributes": {
+            "launch": {
+                "required": [],
+                "properties": {
+                    "wrapperExpression": {
+                        "type": "string",
+                        "description": "Expression to call in console log, with the value represented as $. (E.g. JSON.stringify($)).",
+                        "default": ""
+                    }
+                }
+            }
+        }
     },
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
Really love your extension! I find myself wrapping a lot of console logs in JSON.stringify, so I added a configuration to add a wrapping expression around the logged value. 

<img width="924" alt="Screen Shot 2019-08-10 at 8 03 43 PM" src="https://user-images.githubusercontent.com/8941809/62829070-3afcef00-bbaa-11e9-8806-ff2645ccc7f9.png">

<img width="618" alt="Screen Shot 2019-08-10 at 8 04 46 PM" src="https://user-images.githubusercontent.com/8941809/62829072-40f2d000-bbaa-11e9-98c8-69656169297b.png">
