### PR TITLE
feat: add solidity to supported languages

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -24,7 +24,8 @@ function activate(context) {
             'typescript',
             'javascriptreact',
             'typescriptreact',
-            'vue'
+            'vue',
+            'solidity'
         ]
         if (supportedLangs.includes(lang)) {
             let selection = editor.selection;


### PR DESCRIPTION
You can use `console.log` in solidity as long as you use hardhat: `import "hardhat/console.sol";`.
Would be great to add this the supported languages